### PR TITLE
Migrate to Go modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # go-gir
+
+The following packages do not build:
+
+- gst-1.0
+
+	```
+	# github.com/electricface/go-gir/gst-1.0
+	gst-1.0/gst_auto.go:32492:6: StaticCapsGetType redeclared in this block
+		previous declaration at gst-1.0/gst_auto.go:24368:26
+	gst-1.0/gst_auto.go:32508:6: StaticPadTemplateGetType redeclared in this block
+		previous declaration at gst-1.0/gst_auto.go:24411:33
+	gst-1.0/gst_auto.go:32875:6: TypeFindGetType redeclared in this block
+		previous declaration at gst-1.0/gst_auto.go:28840:24
+	```
+

--- a/atk-1.0/atk_auto.go
+++ b/atk-1.0/atk_auto.go
@@ -52,8 +52,8 @@ return (void*)(myAtkPropertyChangeHandler);
 }
 */
 import "C"
-import "github.com/linuxdeepin/go-gir/g-2.0"
-import "github.com/linuxdeepin/go-gir/gi"
+import "github.com/electricface/go-gir/g-2.0"
+import "github.com/electricface/go-gir/gi"
 import "log"
 import "unsafe"
 

--- a/atspi-2.0/atspi_auto.go
+++ b/atspi-2.0/atspi_auto.go
@@ -44,8 +44,8 @@ return (void*)(myAtspiEventListenerSimpleCB);
 }
 */
 import "C"
-import "github.com/linuxdeepin/go-gir/g-2.0"
-import "github.com/linuxdeepin/go-gir/gi"
+import "github.com/electricface/go-gir/g-2.0"
+import "github.com/electricface/go-gir/gi"
 import "log"
 import "unsafe"
 

--- a/cairo-1.0/cairo_auto.go
+++ b/cairo-1.0/cairo_auto.go
@@ -27,7 +27,7 @@ package cairo
 #cgo pkg-config: cairo-gobject
 */
 import "C"
-import "github.com/linuxdeepin/go-gir/gi"
+import "github.com/electricface/go-gir/gi"
 import "log"
 import "unsafe"
 

--- a/g-2.0/c.go
+++ b/g-2.0/c.go
@@ -45,7 +45,7 @@ import (
 	"sync"
 	"unsafe"
 
-	"github.com/linuxdeepin/go-gir/gi"
+	"github.com/electricface/go-gir/gi"
 )
 
 type closureContext struct {

--- a/g-2.0/gio_auto.go
+++ b/g-2.0/gio_auto.go
@@ -158,7 +158,7 @@ return (void*)(myGioVfsFileLookupFunc);
 }
 */
 import "C"
-import "github.com/linuxdeepin/go-gir/gi"
+import "github.com/electricface/go-gir/gi"
 import "log"
 import "unsafe"
 

--- a/g-2.0/glib_auto.go
+++ b/g-2.0/glib_auto.go
@@ -212,7 +212,7 @@ return (void*)(myGLibVoidFunc);
 }
 */
 import "C"
-import "github.com/linuxdeepin/go-gir/gi"
+import "github.com/electricface/go-gir/gi"
 import "log"
 import "unsafe"
 

--- a/g-2.0/gobject_auto.go
+++ b/g-2.0/gobject_auto.go
@@ -136,7 +136,7 @@ return (void*)(myGObjectWeakNotify);
 }
 */
 import "C"
-import "github.com/linuxdeepin/go-gir/gi"
+import "github.com/electricface/go-gir/gi"
 import "log"
 import "unsafe"
 

--- a/g-2.0/value.go
+++ b/g-2.0/value.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"unsafe"
 
-	"github.com/linuxdeepin/go-gir/gi"
+	"github.com/electricface/go-gir/gi"
 )
 
 /*

--- a/gdk-3.0/gdk_auto.go
+++ b/gdk-3.0/gdk_auto.go
@@ -48,11 +48,11 @@ return (void*)(myGdkWindowInvalidateHandlerFunc);
 }
 */
 import "C"
-import "github.com/linuxdeepin/go-gir/cairo-1.0"
-import "github.com/linuxdeepin/go-gir/g-2.0"
-import "github.com/linuxdeepin/go-gir/gdkpixbuf-2.0"
-import "github.com/linuxdeepin/go-gir/gi"
-import "github.com/linuxdeepin/go-gir/pango-1.0"
+import "github.com/electricface/go-gir/cairo-1.0"
+import "github.com/electricface/go-gir/g-2.0"
+import "github.com/electricface/go-gir/gdkpixbuf-2.0"
+import "github.com/electricface/go-gir/gi"
+import "github.com/electricface/go-gir/pango-1.0"
 import "log"
 import "unsafe"
 

--- a/gdkpixbuf-2.0/gdkpixbuf_auto.go
+++ b/gdkpixbuf-2.0/gdkpixbuf_auto.go
@@ -36,8 +36,8 @@ return (void*)(myGdkPixbufPixbufSaveFunc);
 }
 */
 import "C"
-import "github.com/linuxdeepin/go-gir/g-2.0"
-import "github.com/linuxdeepin/go-gir/gi"
+import "github.com/electricface/go-gir/g-2.0"
+import "github.com/electricface/go-gir/gi"
 import "log"
 import "unsafe"
 

--- a/gdkpixdata-2.0/gdkpixdata_auto.go
+++ b/gdkpixdata-2.0/gdkpixdata_auto.go
@@ -28,9 +28,9 @@ package gdkpixdata
 #include <gdk-pixbuf/gdk-pixdata.h>
 */
 import "C"
-import "github.com/linuxdeepin/go-gir/g-2.0"
-import "github.com/linuxdeepin/go-gir/gdkpixbuf-2.0"
-import "github.com/linuxdeepin/go-gir/gi"
+import "github.com/electricface/go-gir/g-2.0"
+import "github.com/electricface/go-gir/gdkpixbuf-2.0"
+import "github.com/electricface/go-gir/gi"
 import "log"
 import "unsafe"
 

--- a/girepository-2.0/girepository_auto.go
+++ b/girepository-2.0/girepository_auto.go
@@ -28,8 +28,8 @@ package girepository
 #include <girepository.h>
 */
 import "C"
-import "github.com/linuxdeepin/go-gir/g-2.0"
-import "github.com/linuxdeepin/go-gir/gi"
+import "github.com/electricface/go-gir/g-2.0"
+import "github.com/electricface/go-gir/gi"
 import "log"
 import "unsafe"
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/electricface/go-gir
+
+go 1.14

--- a/gst-1.0/gst_auto.go
+++ b/gst-1.0/gst_auto.go
@@ -292,8 +292,8 @@ return (void*)(myGstValueSerializeFunc);
 }
 */
 import "C"
-import "github.com/linuxdeepin/go-gir/g-2.0"
-import "github.com/linuxdeepin/go-gir/gi"
+import "github.com/electricface/go-gir/g-2.0"
+import "github.com/electricface/go-gir/gi"
 import "log"
 import "unsafe"
 

--- a/gstbase-1.0/gstbase_auto.go
+++ b/gstbase-1.0/gstbase_auto.go
@@ -72,9 +72,9 @@ return (void*)(myGstBaseTypeFindHelperGetRangeFunction);
 }
 */
 import "C"
-import "github.com/linuxdeepin/go-gir/g-2.0"
-import "github.com/linuxdeepin/go-gir/gi"
-import "github.com/linuxdeepin/go-gir/gst-1.0"
+import "github.com/electricface/go-gir/g-2.0"
+import "github.com/electricface/go-gir/gi"
+import "github.com/electricface/go-gir/gst-1.0"
 import "log"
 import "unsafe"
 

--- a/gstcontroller-1.0/gstcontroller_auto.go
+++ b/gstcontroller-1.0/gstcontroller_auto.go
@@ -36,9 +36,9 @@ return (void*)(myGstControllerDirectControlBindingConvertValue);
 }
 */
 import "C"
-import "github.com/linuxdeepin/go-gir/g-2.0"
-import "github.com/linuxdeepin/go-gir/gi"
-import "github.com/linuxdeepin/go-gir/gst-1.0"
+import "github.com/electricface/go-gir/g-2.0"
+import "github.com/electricface/go-gir/gi"
+import "github.com/electricface/go-gir/gst-1.0"
 import "log"
 import "unsafe"
 

--- a/gstnet-1.0/gstnet_auto.go
+++ b/gstnet-1.0/gstnet_auto.go
@@ -32,9 +32,9 @@ return (void*)(myGstNetPtpStatisticsCallback);
 }
 */
 import "C"
-import "github.com/linuxdeepin/go-gir/g-2.0"
-import "github.com/linuxdeepin/go-gir/gi"
-import "github.com/linuxdeepin/go-gir/gst-1.0"
+import "github.com/electricface/go-gir/g-2.0"
+import "github.com/electricface/go-gir/gi"
+import "github.com/electricface/go-gir/gst-1.0"
 import "log"
 import "unsafe"
 

--- a/gtk-3.0/gtk.go
+++ b/gtk-3.0/gtk.go
@@ -1,7 +1,7 @@
 package gtk
 
 import (
-	"github.com/linuxdeepin/go-gir/gi"
+	"github.com/electricface/go-gir/gi"
 	"log"
 	"unsafe"
 )

--- a/gtk-3.0/gtk_auto.go
+++ b/gtk-3.0/gtk_auto.go
@@ -282,13 +282,13 @@ return (void*)(myGtkTreeViewSearchPositionFunc);
 }
 */
 import "C"
-import "github.com/linuxdeepin/go-gir/atk-1.0"
-import "github.com/linuxdeepin/go-gir/cairo-1.0"
-import "github.com/linuxdeepin/go-gir/g-2.0"
-import "github.com/linuxdeepin/go-gir/gdk-3.0"
-import "github.com/linuxdeepin/go-gir/gdkpixbuf-2.0"
-import "github.com/linuxdeepin/go-gir/gi"
-import "github.com/linuxdeepin/go-gir/pango-1.0"
+import "github.com/electricface/go-gir/atk-1.0"
+import "github.com/electricface/go-gir/cairo-1.0"
+import "github.com/electricface/go-gir/g-2.0"
+import "github.com/electricface/go-gir/gdk-3.0"
+import "github.com/electricface/go-gir/gdkpixbuf-2.0"
+import "github.com/electricface/go-gir/gi"
+import "github.com/electricface/go-gir/pango-1.0"
 import "log"
 import "unsafe"
 

--- a/gtksource-4/gtksource_auto.go
+++ b/gtksource-4/gtksource_auto.go
@@ -28,12 +28,12 @@ package gtksource
 #include <gtksourceview/gtksource.h>
 */
 import "C"
-import "github.com/linuxdeepin/go-gir/cairo-1.0"
-import "github.com/linuxdeepin/go-gir/g-2.0"
-import "github.com/linuxdeepin/go-gir/gdk-3.0"
-import "github.com/linuxdeepin/go-gir/gdkpixbuf-2.0"
-import "github.com/linuxdeepin/go-gir/gi"
-import "github.com/linuxdeepin/go-gir/gtk-3.0"
+import "github.com/electricface/go-gir/cairo-1.0"
+import "github.com/electricface/go-gir/g-2.0"
+import "github.com/electricface/go-gir/gdk-3.0"
+import "github.com/electricface/go-gir/gdkpixbuf-2.0"
+import "github.com/electricface/go-gir/gi"
+import "github.com/electricface/go-gir/gtk-3.0"
 import "log"
 import "unsafe"
 

--- a/gtop-2.0/gtop_auto.go
+++ b/gtop-2.0/gtop_auto.go
@@ -23,7 +23,7 @@
 
 package gtop
 
-import "github.com/linuxdeepin/go-gir/gi"
+import "github.com/electricface/go-gir/gi"
 import "log"
 import "unsafe"
 

--- a/gudev-1.0/gudev_auto.go
+++ b/gudev-1.0/gudev_auto.go
@@ -28,8 +28,8 @@ package gudev
 #include <gudev/gudev.h>
 */
 import "C"
-import "github.com/linuxdeepin/go-gir/g-2.0"
-import "github.com/linuxdeepin/go-gir/gi"
+import "github.com/electricface/go-gir/g-2.0"
+import "github.com/electricface/go-gir/gi"
 import "log"
 import "unsafe"
 

--- a/pango-1.0/pango_auto.go
+++ b/pango-1.0/pango_auto.go
@@ -40,8 +40,8 @@ return (void*)(myPangoFontsetForeachFunc);
 }
 */
 import "C"
-import "github.com/linuxdeepin/go-gir/g-2.0"
-import "github.com/linuxdeepin/go-gir/gi"
+import "github.com/electricface/go-gir/g-2.0"
+import "github.com/electricface/go-gir/gi"
 import "log"
 import "unsafe"
 

--- a/pangocairo-1.0/pangocairo_auto.go
+++ b/pangocairo-1.0/pangocairo_auto.go
@@ -32,10 +32,10 @@ return (void*)(myPangoCairoShapeRendererFunc);
 }
 */
 import "C"
-import "github.com/linuxdeepin/go-gir/cairo-1.0"
-import "github.com/linuxdeepin/go-gir/g-2.0"
-import "github.com/linuxdeepin/go-gir/gi"
-import "github.com/linuxdeepin/go-gir/pango-1.0"
+import "github.com/electricface/go-gir/cairo-1.0"
+import "github.com/electricface/go-gir/g-2.0"
+import "github.com/electricface/go-gir/gi"
+import "github.com/electricface/go-gir/pango-1.0"
 import "log"
 import "unsafe"
 

--- a/poppler-0.18/poppler_auto.go
+++ b/poppler-0.18/poppler_auto.go
@@ -36,9 +36,9 @@ return (void*)(myPopplerMediaSaveFunc);
 }
 */
 import "C"
-import "github.com/linuxdeepin/go-gir/cairo-1.0"
-import "github.com/linuxdeepin/go-gir/g-2.0"
-import "github.com/linuxdeepin/go-gir/gi"
+import "github.com/electricface/go-gir/cairo-1.0"
+import "github.com/electricface/go-gir/g-2.0"
+import "github.com/electricface/go-gir/gi"
 import "log"
 import "unsafe"
 

--- a/rsvg-2.0/rsvg_auto.go
+++ b/rsvg-2.0/rsvg_auto.go
@@ -28,10 +28,10 @@ package rsvg
 #include <librsvg/rsvg.h>
 */
 import "C"
-import "github.com/linuxdeepin/go-gir/cairo-1.0"
-import "github.com/linuxdeepin/go-gir/g-2.0"
-import "github.com/linuxdeepin/go-gir/gdkpixbuf-2.0"
-import "github.com/linuxdeepin/go-gir/gi"
+import "github.com/electricface/go-gir/cairo-1.0"
+import "github.com/electricface/go-gir/g-2.0"
+import "github.com/electricface/go-gir/gdkpixbuf-2.0"
+import "github.com/electricface/go-gir/gi"
 import "log"
 import "unsafe"
 

--- a/udisks-2.0/udisks_auto.go
+++ b/udisks-2.0/udisks_auto.go
@@ -28,8 +28,8 @@ package udisks
 #include <udisks/udisks.h>
 */
 import "C"
-import "github.com/linuxdeepin/go-gir/g-2.0"
-import "github.com/linuxdeepin/go-gir/gi"
+import "github.com/electricface/go-gir/g-2.0"
+import "github.com/electricface/go-gir/gi"
 import "log"
 import "unsafe"
 

--- a/vte-2.91/vte_auto.go
+++ b/vte-2.91/vte_auto.go
@@ -36,11 +36,11 @@ return (void*)(myVteTerminalSpawnAsyncCallback);
 }
 */
 import "C"
-import "github.com/linuxdeepin/go-gir/g-2.0"
-import "github.com/linuxdeepin/go-gir/gdk-3.0"
-import "github.com/linuxdeepin/go-gir/gi"
-import "github.com/linuxdeepin/go-gir/gtk-3.0"
-import "github.com/linuxdeepin/go-gir/pango-1.0"
+import "github.com/electricface/go-gir/g-2.0"
+import "github.com/electricface/go-gir/gdk-3.0"
+import "github.com/electricface/go-gir/gi"
+import "github.com/electricface/go-gir/gtk-3.0"
+import "github.com/electricface/go-gir/pango-1.0"
 import "log"
 import "unsafe"
 


### PR DESCRIPTION
Although this repository contains mostly autogenerated code, it is still a good idea to use Go modules here. `go-gir3` also relies on `go-gir/gi`, which is in this repository, so I think this is the right move.

Large changes include:

- Changed all `github.com/linuxdeepin/go-gir` imports to `github.com/electricface/go-gir`
- Go modules initialized as `github.com/electricface/go-gir` at Go 1.14

You may need to move your projects outside GOPATH, but seriously, who even uses GOPATH these days?